### PR TITLE
Fix issue #53: Add timestamps to models

### DIFF
--- a/photo/migrations/0002_add_timestamps.py
+++ b/photo/migrations/0002_add_timestamps.py
@@ -1,0 +1,85 @@
+from django.db import migrations, models
+import django.utils.timezone
+
+
+def add_timestamps(apps, schema_editor):
+    models = [
+        'User',
+        'Picture',
+        'PictureComment',
+        'Collection',
+        'Contest',
+        'ContestSubmission',
+    ]
+    for model_name in models:
+        Model = apps.get_model('photo', model_name)
+        for obj in Model.objects.all():
+            obj.created_at = django.utils.timezone.now()
+            obj.updated_at = django.utils.timezone.now()
+            obj.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('photo', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='created_at',
+            field=models.DateTimeField(auto_now_add=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='user',
+            name='updated_at',
+            field=models.DateTimeField(auto_now=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='picture',
+            name='created_at',
+            field=models.DateTimeField(auto_now_add=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='picture',
+            name='updated_at',
+            field=models.DateTimeField(auto_now=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='picturecomment',
+            name='updated_at',
+            field=models.DateTimeField(auto_now=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='collection',
+            name='created_at',
+            field=models.DateTimeField(auto_now_add=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='collection',
+            name='updated_at',
+            field=models.DateTimeField(auto_now=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='contest',
+            name='created_at',
+            field=models.DateTimeField(auto_now_add=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='contest',
+            name='updated_at',
+            field=models.DateTimeField(auto_now=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='contestsubmission',
+            name='created_at',
+            field=models.DateTimeField(auto_now_add=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='contestsubmission',
+            name='updated_at',
+            field=models.DateTimeField(auto_now=True, null=True),
+        ),
+        migrations.RunPython(add_timestamps),
+    ]

--- a/photo/models.py
+++ b/photo/models.py
@@ -46,7 +46,15 @@ class UserManager(BaseUserManager):
         return self.create_user(email, password, **kwargs)
 
 
-class SoftDeleteModel(models.Model):
+class TimestampedModel(models.Model):
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        abstract = True
+
+
+class SoftDeleteModel(TimestampedModel):
     is_deleted = models.BooleanField(default=False)
     objects = SoftDeleteManager()
     all_objects = models.Manager()

--- a/photo/tests/test_database/test_user.py
+++ b/photo/tests/test_database/test_user.py
@@ -23,6 +23,10 @@ class UserTest(TransactionTestCase):
             User.objects.first().profile_picture.file,
         )
 
+    def test_timestamps(self):
+        self.assertIsNotNone(self.user.created_at)
+        self.assertIsNotNone(self.user.updated_at)
+
     def test_factory_pk(self):
         with self.assertRaises(IntegrityError):
             UserFactory(id=self.user.id)


### PR DESCRIPTION
This pull request fixes #53.

The issue of adding 'created_at' and 'updated_at' fields to all models has been successfully resolved. The AI agent introduced a new `TimestampedModel` abstract class, which includes these timestamp fields, and applied it to all models. This ensures that every model now has the required fields. Additionally, a migration file was created to add these fields to existing models and populate them for existing records, ensuring backward compatibility and data integrity. A test case was also added to verify that the `created_at` and `updated_at` fields are correctly set for a user instance, confirming the functionality of the changes. These steps comprehensively address the issue as described.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌