### PR TITLE
Fix issue #59: Add timestamps to models

### DIFF
--- a/photo/models.py
+++ b/photo/models.py
@@ -46,7 +46,15 @@ class UserManager(BaseUserManager):
         return self.create_user(email, password, **kwargs)
 
 
-class SoftDeleteModel(models.Model):
+class TimestampedModel(models.Model):
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        abstract = True
+
+
+class SoftDeleteModel(TimestampedModel):
     is_deleted = models.BooleanField(default=False)
     objects = SoftDeleteManager()
     all_objects = models.Manager()


### PR DESCRIPTION
This pull request fixes #59.

The issue has been successfully resolved as the primary requirement was to add `created_at` and `updated_at` fields to all models. This was achieved by introducing a `TimestampedModel` abstract class containing these fields. The `SoftDeleteModel` now inherits from `TimestampedModel`, ensuring that all models extending `SoftDeleteModel` will automatically include the timestamp fields. The changes were made in the `/workspace/photo/models.py` file, which aligns with the task's requirements. Although the test suite could not be executed due to an unavailable local S3 service, the code changes themselves fulfill the task's objectives.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌