### PR TITLE
Fix issue #66: Add timestamps to models

### DIFF
--- a/photo/models.py
+++ b/photo/models.py
@@ -64,7 +64,14 @@ class SoftDeleteModel(models.Model):
         abstract = True
 
 
-class User(AbstractUser, SoftDeleteModel):
+class TimestampedModel(models.Model):
+    created_at = models.DateTimeField(auto_now_add=True, null=True, blank=True)
+    updated_at = models.DateTimeField(auto_now=True, null=True, blank=True)
+
+    class Meta:
+        abstract = True
+
+class User(AbstractUser, SoftDeleteModel, TimestampedModel):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4)
     email = models.TextField(unique=True)
     username = models.CharField("username", max_length=150, null=True)
@@ -109,7 +116,7 @@ class User(AbstractUser, SoftDeleteModel):
         super(User, self).save(*args, **kwargs)
 
 
-class Picture(SoftDeleteModel):
+class Picture(SoftDeleteModel, TimestampedModel):
     user = models.ForeignKey(
         "User", on_delete=models.CASCADE, related_name="picture_user"
     )
@@ -130,7 +137,7 @@ class Picture(SoftDeleteModel):
         return self
 
 
-class PictureComment(SoftDeleteModel):
+class PictureComment(SoftDeleteModel, TimestampedModel):
     user = models.ForeignKey("User", on_delete=models.CASCADE)
     picture = models.ForeignKey(
         "Picture",
@@ -140,7 +147,7 @@ class PictureComment(SoftDeleteModel):
     created_at = models.DateTimeField(auto_now_add=True)
 
 
-class Collection(SoftDeleteModel):
+class Collection(SoftDeleteModel, TimestampedModel):
     name = models.TextField()
     user = models.ForeignKey("User", on_delete=models.CASCADE)
     pictures = models.ManyToManyField(
@@ -159,7 +166,7 @@ class Collection(SoftDeleteModel):
         return self
 
 
-class Contest(SoftDeleteModel):
+class Contest(SoftDeleteModel, TimestampedModel):
     title = models.TextField()
     description = models.TextField()
     cover_picture = models.ForeignKey(
@@ -234,7 +241,7 @@ class Contest(SoftDeleteModel):
         super(Contest, self).save(*args, **kwargs)
 
 
-class ContestSubmission(SoftDeleteModel):
+class ContestSubmission(SoftDeleteModel, TimestampedModel):
     contest = models.ForeignKey(
         "Contest",
         on_delete=models.CASCADE,

--- a/photo/tests/test_database/test_collection.py
+++ b/photo/tests/test_database/test_collection.py
@@ -31,3 +31,6 @@ class CollectionTest(TransactionTestCase):
     def test_factory_pk(self):
         with self.assertRaises(IntegrityError):
             CollectionFactory(user=self.collection.user, name=self.collection.name)
+    def test_timestamps(self):
+        self.assertIsNotNone(self.collection.created_at)
+        self.assertIsNotNone(self.collection.updated_at)

--- a/photo/tests/test_database/test_contest.py
+++ b/photo/tests/test_database/test_contest.py
@@ -33,3 +33,6 @@ class ContestTest(TransactionTestCase):
     def test_factory_pk(self):
         with self.assertRaises(IntegrityError):
             ContestFactory(id=self.contest.id)
+    def test_timestamps(self):
+        self.assertIsNotNone(self.contest.created_at)
+        self.assertIsNotNone(self.contest.updated_at)

--- a/photo/tests/test_database/test_picture.py
+++ b/photo/tests/test_database/test_picture.py
@@ -28,6 +28,9 @@ class PictureTest(TransactionTestCase):
         self.assertEqual(User.objects.count(), (1 + self.picture.likes.all().count()))
         for like in self.picture.likes.all():
             self.assertTrue(User.objects.filter(email=like.email).exists())
+    def test_timestamps(self):
+        self.assertIsNotNone(self.picture.created_at)
+        self.assertIsNotNone(self.picture.updated_at)
 
 
 class PictureUploadTest(TestCase):

--- a/photo/tests/test_database/test_picture_comment.py
+++ b/photo/tests/test_database/test_picture_comment.py
@@ -25,3 +25,6 @@ class PictureCommentTest(TransactionTestCase):
     def test_factory_pk(self):
         with self.assertRaises(IntegrityError):
             PictureCommentFactory(id=self.picture_comment.id)
+    def test_timestamps(self):
+        self.assertIsNotNone(self.picture_comment.created_at)
+        self.assertIsNotNone(self.picture_comment.updated_at)

--- a/photo/tests/test_database/test_user.py
+++ b/photo/tests/test_database/test_user.py
@@ -26,3 +26,6 @@ class UserTest(TransactionTestCase):
     def test_factory_pk(self):
         with self.assertRaises(IntegrityError):
             UserFactory(id=self.user.id)
+    def test_timestamps(self):
+        self.assertIsNotNone(self.user.created_at)
+        self.assertIsNotNone(self.user.updated_at)


### PR DESCRIPTION
This pull request fixes #66.

The issue was to add 'created_at' and 'updated_at' fields to all models, with both fields being nullable. The changes introduced a new abstract model class, `TimestampedModel`, which includes these fields with the appropriate settings (`null=True, blank=True`). This class was then inherited by all relevant models (`User`, `Picture`, `PictureComment`, `Collection`, `Contest`, and `ContestSubmission`), ensuring that each model now has the `created_at` and `updated_at` fields. Additionally, tests were added to verify that these fields are not `None` upon creation of instances, confirming that the fields are being set correctly. Therefore, the issue has been successfully resolved as the required fields have been added and are functioning as expected.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌