### PR TITLE
Fix issue #89: Create winners view

### DIFF
--- a/photo/queries.py
+++ b/photo/queries.py
@@ -130,3 +130,9 @@ class Query:
         else:
             query_results.sort(key=set_order)
         return query_results
+
+    @strawberry.field
+    def winners(self) -> List[ContestType]:
+        contests_with_winners = Contest.objects.filter(winners__isnull=False).distinct()
+        contests_with_winners = contests_with_winners.order_by('-voting_phase_end')
+        return contests_with_winners

--- a/photo/tests/test_queries/test_contest.py
+++ b/photo/tests/test_queries/test_contest.py
@@ -109,6 +109,33 @@ class ContestTest(TestCase):
             self.assertEqual(contest["status"], status[str(contest["id"])])
 
 
+    def test_winners_query(self):
+        user = UserFactory()
+        contest = ContestFactory(created_by=user)
+        contest.winners.add(user)
+        contest.save()
+
+        result = schema.execute_sync(
+            """
+            query {
+                winners {
+                    id
+                    title
+                    winners {
+                        id
+                        email
+                    }
+                }
+            }
+            """,
+            variable_values={}
+        )
+
+        self.assertEqual(result.errors, None)
+        self.assertEqual(len(result.data["winners"]), 1)
+        self.assertEqual(result.data["winners"][0]["id"], str(contest.id))
+        self.assertEqual(result.data["winners"][0]["winners"][0]["id"], str(user.id))
+
 class ContestFilterTest(TestCase):
     def test_filter_by_search(self):
         test_text = "This is a text with a weird word 1234Test1234."


### PR DESCRIPTION
This pull request fixes #89.

The changes made in the PR successfully address the issue by implementing a new GraphQL view that returns contests with winners. The `winners` method was added to the `Query` class, which filters contests to include only those with winners and orders them by the date the contest ended (`voting_phase_end`). The test `test_winners_query` was also added to verify that the query returns the correct data structure, including the contest ID and the list of winners with their IDs and emails. The test passes without errors, indicating that the query works as expected and fulfills the requirements outlined in the issue description.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌